### PR TITLE
Custom property type support for filtering and sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ public class SieveCustomFilterMethods : ISieveCustomFilterMethods
 
 ### Add custom type conversions.
 
-Sieve has to do a type conversion from the keys in you filter query string to the actual field type in your object you'd like to filter or sort on. Sieve covers this by default for the build in C# types. For filtering and sorting on custom types like for example a [Bson ObjectId](https://mongodb.github.io/mongo-csharp-driver/2.12/apidocs/html/T_MongoDB_Bson_ObjectId.htm) you could use a `ISieveCustomTypeConverter`
+Sieve has to do a type conversion from the keys in you filter query string to the actual field type in your object you'd like to filter or sort on. Sieve covers this by default for the built-in C# types. For filtering and sorting on custom types like for example a [Bson ObjectId](https://mongodb.github.io/mongo-csharp-driver/2.12/apidocs/html/T_MongoDB_Bson_ObjectId.htm) you could use a `ISieveCustomTypeConverter`
 ```C#
 public class SieveObjectIdTypeConverter : ISieveCustomTypeConverter
 {

--- a/README.md
+++ b/README.md
@@ -115,6 +115,30 @@ public class SieveCustomFilterMethods : ISieveCustomFilterMethods
 }
 ```
 
+### Add custom type conversions.
+
+Sieve has to do a type conversion from the keys in you filter query string to the actual field type in your object you'd like to filter or sort on. Sieve covers this by default for the build in C# types. For filtering and sorting on custom types like for example a [Bson ObjectId](https://mongodb.github.io/mongo-csharp-driver/2.12/apidocs/html/T_MongoDB_Bson_ObjectId.htm) you could use a `ISieveCustomTypeConverter`
+```C#
+public class SieveObjectIdTypeConverter : ISieveCustomTypeConverter
+{
+    /// Return your custom type here.
+    public bool CanConvert(Type targetType)
+    {
+        return targetType == typeof(ObjectId);
+    }
+
+    /// Handle this conversion from string to you custom type.
+    public object Convert(string value)
+    {
+        if (value != null && ObjectId.TryParse(value, out var parsedValue))
+        {
+            return parsedValue;
+        }
+        return ObjectId.Empty;
+    }
+}
+```
+
 ## Configure Sieve
 Use the [ASP.NET Core options pattern](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options) with `SieveOptions` to tell Sieve where to look for configuration. For example:
 ```C#

--- a/Sieve/Services/ISieveCustomTypeConverter.cs
+++ b/Sieve/Services/ISieveCustomTypeConverter.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Sieve.Services
+{
+    /// <summary>
+    /// Interface for implementing custom type conversions to be able to filter or sort on a non system type.
+    /// </summary>
+    public interface ISieveCustomTypeConverter
+    {
+        /// <summary>
+        /// Determines wether this converter is able to convert given type.
+        /// </summary>
+        /// <param name="targetType"></param>
+        /// <returns></returns>
+        bool CanConvert(Type targetType);
+
+        /// <summary>
+        /// Converts value to target type.
+        /// </summary>
+        object Convert(string value);
+    }
+}

--- a/Sieve/Sieve.csproj
+++ b/Sieve/Sieve.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.3.3</Version>
+    <Version>2.5.0</Version>
     <Description>Sieve is a simple, clean, and extensible framework for .NET Core that adds sorting, filtering, and pagination functionality out of the box. Most common use case would be for serving ASP.NET Core GET queries. Documentation available on GitHub: https://github.com/Biarity/Sieve/
 </Description>
     <Copyright>Copyright 2018</Copyright>


### PR DESCRIPTION
We ran into the problem that Sieve doesn't support filtering and sorting on other property types then the (dotnet) build in types. Though the source code of Sieve I found out that custom type conversion was possible with a [typeconverter](https://docs.microsoft.com/en-us/dotnet/api/system.componentmodel.typeconverter?redirectedfrom=MSDN&view=net-5.0) but that is impossible to implement if your custom type comes from a library.

To solve this problem I've build a solution where you can define custom type conversions.
Things done:

- Create an interface for defining your custom type conversion.
- Added SieveProcessor constructors for which you can configure these custom conversions.
- Implemented usage of the custom type conversions into the SieveProcessor.
- Updated the `README.md` documentation including the configuration of a custom type conversion.